### PR TITLE
Resizing width of Add Employee Button

### DIFF
--- a/src/app/components/employees/view-employee/view-employee.component.css
+++ b/src/app/components/employees/view-employee/view-employee.component.css
@@ -174,10 +174,12 @@ input[type="number"] {
     background: var(--primary-color);
     align-self: flex-end;
     width: 224px;
+    max-width: 53%
 }
 
 .add-employee-span {
   margin-right: 3%;
+  font-size: var(--font-size-1);
 }
 
 #add-employee-button mat-icon {
@@ -193,7 +195,6 @@ input[type="number"] {
     padding: 10px 16px;
     background: var(--primary-color);
     color: white;
-    font-weight: 500;
     font-size: var(--font-size-1);
     border-radius: 8px;
 }
@@ -212,6 +213,7 @@ input[type="number"] {
 .role-text {
     flex-grow: 1;
     text-align: center;
+    font-weight: 400;
     color:white;
 }
 

--- a/src/app/components/employees/view-employee/view-employee.component.html
+++ b/src/app/components/employees/view-employee/view-employee.component.html
@@ -16,7 +16,7 @@
       </div>
       <div class="col-6 pr-0 d-flex justify-content-end align-items-center gap-3">
         <button (click)="onAddEmployeeClick()" type="button" id="add-employee-button"
-          class="col-lg-4 col-md-6 btn btn-primary rounded-pill d-flex justify-content-center align-items-center">
+          class="col-lg-4 btn btn-primary rounded-pill d-flex justify-content-center align-items-center">
           <mat-icon>add</mat-icon>
           <span class="add-employee-span">Add Employee</span>
         </button>


### PR DESCRIPTION
Making the width of the Add Employee button smaller and aligning the button text - View Employees Page
![224PX_Add_Employees_Mobile.png](https://github.com/RetroRabbit/RGO-Client/assets/8848922/85ba1500-7cb3-41a3-897c-50cf9890fcc6) 
![224PX_Add_Employees_Resized.png](https://github.com/RetroRabbit/RGO-Client/assets/8848922/730ddc16-7323-4a74-a9d4-2bc63c86a764) 
![224PX_Add_Employee_Desktop.png](https://github.com/RetroRabbit/RGO-Client/assets/8848922/9c7967c0-a6ce-4643-95a4-b3c67f95f6f5) 