### PR TITLE
Fixed overflow on small screen for employee info

### DIFF
--- a/src/app/components/hris/nav-bar/nav-bar.component.css
+++ b/src/app/components/hris/nav-bar/nav-bar.component.css
@@ -14,6 +14,12 @@
     display: inline-block;
   }
 
+  #employee-info {
+    height: 18px;
+    display: flex;
+    flex-direction: column;
+  }
+
   #menu-image-container{
     width: 40px;
     height: 40px;

--- a/src/app/components/hris/nav-bar/nav-bar.component.html
+++ b/src/app/components/hris/nav-bar/nav-bar.component.html
@@ -194,7 +194,7 @@
           </button>
         </mat-menu>
       </div>
-      <div class="col-auto ms-4" id="employee-info" style="height: 18px; display: flex; flex-direction: column;">
+      <div class="col-auto ms-4" id="employee-info">
         <div *ngIf="isLoading; else ProfileNameSurname" id="loader-style">
           <ngx-skeleton-loader appearance="line" count="1" [theme]="{color: '#E0E0E0', borderRadius: '4px'}"></ngx-skeleton-loader>
         </div>


### PR DESCRIPTION
**Bug information:**
_Display inline block overrides the 'hide' function. Used flexbox to solve the problem_
![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/4e0a99d3-a69d-4cf0-a84f-45e4e8bfc943)

**Fixed:**
_Employee info doesn't overflow anymore and is hidden on small screens like intended_
![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/bb5cf26e-0933-4b63-8e28-7f31d171f5cf)
![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/f66a43ed-ca3b-4dc2-a9f0-fd01b55c0848)
