### PR TITLE
Prevent API call from happening if there is no data for the country

### DIFF
--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-address-details/accordion-profile-address-details.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-address-details/accordion-profile-address-details.component.ts
@@ -228,6 +228,10 @@ export class AccordionProfileAddressDetailsComponent {
       },
       complete: () => {    
         this.selectedCountry = this.employeeProfile!.employeeDetails.physicalAddress?.country!
+        if(this.selectedCountry == " ")
+          {
+            return;
+          }
         this.locationApiService.getProvinces(this.selectedCountry).subscribe({
           next: (data) => this.provinces = data,
           error: (error: any) => {
@@ -259,6 +263,10 @@ export class AccordionProfileAddressDetailsComponent {
       },
       complete: () => {    
         this.selectedPostalCountry = this.employeeProfile!.employeeDetails.postalAddress?.country!
+        if(this.selectedPostalCountry == " ")
+          {
+            return;
+          }
         this.locationApiService.getProvinces(this.selectedPostalCountry).subscribe({
           next: (data) => this.postalProvinces = data,
           error: (error: any) => {


### PR DESCRIPTION
![image](https://github.com/RetroRabbit/RGO-Client/assets/156077669/9af5bd04-2730-44db-b3ee-46d2c5c00dd8)

Errors no longer gets thrown to the console, if the accordion has no data
Accordions API calls still works as intended when data has been entered.