### PR TITLE
Bug 8899 | Users with "Employee" Role get's logged out immediately

### DIFF
--- a/src/app/services/shared-services/nav-service/nav.service.ts
+++ b/src/app/services/shared-services/nav-service/nav.service.ts
@@ -29,7 +29,11 @@ export class NavService {
       next: (data) => {
         this.employeeProfile = data;
         this.authAccessService.setUserId(this.employeeProfile.id as number);
-        this.cookieService.set("userId", String(this.employeeProfile.id));
+        this.cookieService.set("userId", String(this.employeeProfile.id), {
+          path: '/',
+          secure: true,
+          sameSite: 'None'
+        });
       }
     });
   }


### PR DESCRIPTION
### Overview

Implemented token validation and enhanced cookie security.

**Problem**

This pull request proposes a potential solution for addressing the issue where the Employee Role gets logged out after logging in.

 This problem may arise due to the rejection of HttpOnly cookies when using TLS. By implementing the suggested changes, we aim to mitigate this issue and ensure smoother authentication experiences for users with the Employee Role.

[Bug 8899](https://dev.azure.com/retro-rabbit/RetroGradOnboard/_sprints/taskboard/RetroGradOnboard%20Team/RetroGradOnboard/Sprint%2021?workitem=8899)