### PR TITLE
Pre-selected Document Type Implementation

### DIFF
--- a/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.html
+++ b/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.html
@@ -7,7 +7,7 @@
                 <mat-form-field appearance="outline" style="width: 100%;">
                     <mat-label>Name</mat-label>
                     <input matInput formControlName="name" (input)="formatCustomFieldCodeFromName()"
-                        [(ngModel)]="fieldCodeCapture">
+                        [(ngModel)]="fieldCodeCapture" (change)="onRadioChange()" >
                 </mat-form-field>
             </div>
             <div class="col-12">
@@ -27,7 +27,7 @@
             </div>
             <div class="col-12">
                 <h1 id="radio-headings" class="mb-0">Select what type of field it should be</h1>
-                <mat-radio-group aria-label="Type" formControlName="type" (change)="checkSelectedOption($event)" (change)="onRadioChange()" [(ngModel)]="selectedOptionType">
+                <mat-radio-group aria-label="Type" formControlName="type" (change)="onRadioChange()" [(ngModel)]="selectedOptionType">
                     <mat-radio-button [value]=0 [disabled]="isDisabledDocuments()">Date - For specific calendar days, like birthdays</mat-radio-button>
                     <br>
                     <mat-radio-button [value]=1 [disabled]="isDisabledDocuments()">String - For storing text, like names or messages</mat-radio-button>

--- a/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.html
+++ b/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.html
@@ -7,7 +7,7 @@
                 <mat-form-field appearance="outline" style="width: 100%;">
                     <mat-label>Name</mat-label>
                     <input matInput formControlName="name" (input)="formatCustomFieldCodeFromName()"
-                        [(ngModel)]="fieldCodeCapture" (change)="onRadioChange()" >
+                        [(ngModel)]="fieldCodeCapture" (change)="onValueChange()" >
                 </mat-form-field>
             </div>
             <div class="col-12">
@@ -27,7 +27,7 @@
             </div>
             <div class="col-12">
                 <h1 id="radio-headings" class="mb-0">Select what type of field it should be</h1>
-                <mat-radio-group aria-label="Type" formControlName="type" (change)="onRadioChange()" [(ngModel)]="selectedOptionType">
+                <mat-radio-group aria-label="Type" formControlName="type" [(ngModel)]="selectedOptionType" (change)="OnRadioChange($event)">
                     <mat-radio-button [value]=0 [disabled]="isDisabledDocuments()">Date - For specific calendar days, like birthdays</mat-radio-button>
                     <br>
                     <mat-radio-button [value]=1 [disabled]="isDisabledDocuments()">String - For storing text, like names or messages</mat-radio-button>
@@ -38,7 +38,7 @@
                     <br>
                     <mat-radio-button [value]=4 [disabled]="isDisabledDocuments()">Options - Choices, which can be words or numbers</mat-radio-button>
                     <br>
-                    <mat-radio-button [value]=5 [disabled]="isDisabled()">Documents - For file uploads, personal or required documents</mat-radio-button>
+                    <mat-radio-button [value]=5 [disabled]="isDisabled()" [checked]="defaultDocumentType">Documents - For file uploads, personal or required documents</mat-radio-button>
 
                 </mat-radio-group>
                 <div *ngIf="customFieldForm.get('type')?.value == 4 && customFieldForm.get('options') as optionsArray; "

--- a/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.ts
+++ b/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.ts
@@ -63,7 +63,6 @@ export class SaveCustomFieldComponent {
     public navService: NavService,
     public systemService: SystemNav) {
     this.selectedCustomField = systemService.selectedField;
-
   }
 
   ngOnInit() {
@@ -74,7 +73,6 @@ export class SaveCustomFieldComponent {
     if (this.selectedCustomField) {
       this.populateCustomFieldForm();
     }
-
   }
 
   ngOnDestroy() {

--- a/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.ts
+++ b/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.ts
@@ -67,6 +67,7 @@ export class SaveCustomFieldComponent {
   }
 
   ngOnInit() {
+    this.onRadioChange();
     this.navService.hideNav();
     this.navService.showSystemNavbar = false;
     this.options.push(this.fb.control(''));
@@ -87,12 +88,12 @@ export class SaveCustomFieldComponent {
 
   addOption() {
     this.options.push(this.fb.control(''));
-    this.checkSelectedOption(5);
+    this.onRadioChange()
   }
 
   removeOption(index: number) {
     this.options.removeAt(index);
-    this.checkSelectedOption(5);
+    this.onRadioChange()
   }
 
   onSubmit() {
@@ -179,23 +180,12 @@ export class SaveCustomFieldComponent {
     });
   }
 
-  checkSelectedOption(e: any) {
-    this.selectedType = this.selectedCustomField?.type;
-    if (this.selectedType === null) {
-      this.optionsValid = true
-    }
-    else {
-      this.optionsValid = false
-    }
-  }
-
   isDisabled() {
     this.defaultDocumentsection = true;
     return this.showTypeFields;
   }
 
   isDisabledDocuments() {
-    this.selectedType = this.selectedCustomField?.type;
     this.defaultDocumentsection = false;
     return this.showDocumentFields;
   }
@@ -204,17 +194,18 @@ export class SaveCustomFieldComponent {
     this.showTypeFields = true;
     this.showDocumentFields = false;
     this.defaultDocumentType = false;
+    this.onRadioChange();
   }
 
   checkOptionDocuments(option: any) {
     this.showDocumentFields = true;
     this.showTypeFields = false;
     this.defaultDocumentType = true;
-    this.optionsValid = false;
+    this.onRadioChange();
   }
 
   onRadioChange(): void {
-    if (this.selectedOption && this.fieldCodeCapture) {
+    if ((this.selectedOption && this.fieldCodeCapture) || (this.selectedOption == '0' && this.fieldCodeCapture)) {
       this.optionsValid = false;
     }
     else {

--- a/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.ts
+++ b/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.ts
@@ -25,7 +25,7 @@ export class SaveCustomFieldComponent {
   isArchiveClicked: boolean = false;
   fieldCodeCapture: string = "";
   selectedOption: string = "";
-  selectedOptionType: string = "";
+  selectedOptionType: number = -1;
   showAdvanced: boolean = false;
   showTypeFields: boolean = false;
   showDocumentFields: boolean = false;
@@ -36,7 +36,6 @@ export class SaveCustomFieldComponent {
   isRequired: boolean = false;
   PREVIOUS_PAGE = "previousPage";
   optionsValid: boolean = true;
-
   customFieldForm: FormGroup = this.fb.group({
     code: ['', Validators.required],
     name: ['', [Validators.required]],
@@ -64,10 +63,10 @@ export class SaveCustomFieldComponent {
     public navService: NavService,
     public systemService: SystemNav) {
     this.selectedCustomField = systemService.selectedField;
+
   }
 
   ngOnInit() {
-    this.onRadioChange();
     this.navService.hideNav();
     this.navService.showSystemNavbar = false;
     this.options.push(this.fb.control(''));
@@ -75,6 +74,7 @@ export class SaveCustomFieldComponent {
     if (this.selectedCustomField) {
       this.populateCustomFieldForm();
     }
+
   }
 
   ngOnDestroy() {
@@ -88,12 +88,12 @@ export class SaveCustomFieldComponent {
 
   addOption() {
     this.options.push(this.fb.control(''));
-    this.onRadioChange()
+    this.onValueChange()
   }
 
   removeOption(index: number) {
     this.options.removeAt(index);
-    this.onRadioChange()
+    this.onValueChange()
   }
 
   onSubmit() {
@@ -194,22 +194,24 @@ export class SaveCustomFieldComponent {
     this.showTypeFields = true;
     this.showDocumentFields = false;
     this.defaultDocumentType = false;
-    this.onRadioChange();
+  }
+
+  OnRadioChange(e: MatRadioChange) {
+    this.checkFields();
   }
 
   checkOptionDocuments(option: any) {
+    this.selectedOptionType = 5;
     this.showDocumentFields = true;
     this.showTypeFields = false;
     this.defaultDocumentType = true;
-    this.onRadioChange();
+    this.checkFields();
   }
 
-  onRadioChange(): void {
-    if ((this.selectedOption && this.fieldCodeCapture) || (this.selectedOption == '0' && this.fieldCodeCapture)) {
-      this.optionsValid = false;
-    }
-    else {
-      this.optionsValid = true;
-    }
+  checkFields(): void {
+    this.optionsValid = this.fieldCodeCapture ? false : true;
+  }
+  onValueChange(): void {
+    this.optionsValid = this.selectedOption && this.fieldCodeCapture && this.selectedOptionType ? false : true;
   }
 }

--- a/src/app/models/hris/constants/types.constants.ts
+++ b/src/app/models/hris/constants/types.constants.ts
@@ -4,5 +4,5 @@ export const dataTypes = [
     { id: 2, value: 'Int' },
     { id: 3, value: 'Float' },
     { id: 4, value: 'Options' },
-    { id: 5, value: 'CustomDocuments' }
+    { id: 5, value: 'Documents' }
 ]


### PR DESCRIPTION
**Description**: Before the Documents type was not preselected and when it was preselected it threw an error saying "missing information" but now it adds the field code to the table successfully

**Before:** 
![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/69ab0e85-8182-4808-a563-77947b352e82)

**After:**
**Pre-selected by default when document is selected:**
![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/0aad9621-c2eb-432c-95e4-b8a1cc29d493)

**Added successfully without throwing an error:**
![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/41012ec8-86c1-4e46-b485-e0c0c62fbd49)
