### PR TITLE
Bug 8899 | Users with "Employee" Role get's logged out immediately (Solution 2)

### DIFF
--- a/src/app/ats-guard.guard.ts
+++ b/src/app/ats-guard.guard.ts
@@ -21,7 +21,6 @@ export class AtsPageGuard {
     }
 
     if (this.navService.isHris == undefined) {
-      if (environment.development) {
         this.navService.isHris = Boolean(JSON.parse(this.cookieService.get('isHris')));
         this.authService.FetchRoles(this.cookieService.get('userEmail')).subscribe({
           next: roles => {
@@ -31,6 +30,5 @@ export class AtsPageGuard {
         return true;
       }
       this.authService.logout()
-    }
   }
 }

--- a/src/app/hris-guard.guard.ts
+++ b/src/app/hris-guard.guard.ts
@@ -22,7 +22,6 @@ export class HrisPageGuard {
     }
 
     if (this.navService.isHris == undefined) {
-      if (environment.development) {
         this.navService.isHris = Boolean(this.cookieService.get('isHris'));
         this.authService.FetchRoles(this.cookieService.get('userEmail')).subscribe({
           next: roles => {
@@ -30,8 +29,6 @@ export class HrisPageGuard {
           }
         });
         return true;
-      }
-      this.authService.logout()
     }
   }
 }


### PR DESCRIPTION
### Overview
Previously, the solution had an issue with the environment.development variable causing logout to occur in a different environment. To address this, the PR removes the environment.development check and ensures consistent behavior regardless of the environment.

An attempt to fix this issue was submitted Previously here:
[ Bug 8899 | Users with "Employee" Role get's logged out immediately (Solution 1)](https://github.com/RetroRabbit/RGO-Client/pull/420)

[Bug 8899 | Azure board](https://dev.azure.com/retro-rabbit/RetroGradOnboard/_sprints/taskboard/RetroGradOnboard%20Team/RetroGradOnboard/Sprint%2021?workitem=8899)