### PR TITLE
Custom documents archive

### DIFF
--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.html
@@ -9,7 +9,7 @@
                     <mat-icon class="mx-1">error</mat-icon><span class="d-none d-md-block d-lg-block">Missing information</span>
                 </mat-panel-description>
             </mat-expansion-panel-header>
-            <div id="table" *ngIf="sharedAccordionFunctionality.customFieldsDocuments[0] != undefined; else NoFieldCodes">
+            <div id="table" *ngIf="unArchivedCustomDocuments[0] != undefined; else NoFieldCodes">
                 <div id="table-header" class="row pt-3 d-none d-md-flex d-lg-flex">
                     <div class="col-6" >
                         <h4 class="ms-2 mt-1">Document</h4>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.html
@@ -9,7 +9,7 @@
                     <mat-icon class="mx-1">error</mat-icon><span class="d-none d-md-block d-lg-block">Missing information</span>
                 </mat-panel-description>
             </mat-expansion-panel-header>
-            <div id="table" *ngIf="unArchivedCustomDocuments[0] != undefined; else NoFieldCodes">
+            <div id="table" *ngIf="unarchivedCustomDocuments[0] != undefined; else NoFieldCodes">
                 <div id="table-header" class="row pt-3 d-none d-md-flex d-lg-flex">
                     <div class="col-6" >
                         <h4 class="ms-2 mt-1">Document</h4>
@@ -19,8 +19,8 @@
                     </div>
                 </div>
                 </div>
-                <div id="table-body" class="my-2" *ngIf="unArchivedCustomDocuments[0] != undefined">
-                    <div class="row my-2 py-2" id="document-row" *ngFor="let fieldcode of unArchivedCustomDocuments;let i = index">
+                <div id="table-body" class="my-2" *ngIf="unarchivedCustomDocuments[0] != undefined">
+                    <div class="row my-2 py-2" id="document-row" *ngFor="let fieldcode of unarchivedCustomDocuments;let i = index">
                         <div id="document" class="col-12 col-md-6 col-lg-6" >
                             <h3>{{fieldcode.name}}</h3>
                             <div class="col-12" id="fileName" *ngIf="getDocumentName(fieldcode.name) as document;else NoFile" id="fileName">

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.html
@@ -19,8 +19,8 @@
                     </div>
                 </div>
                 </div>
-                <div id="table-body" class="my-2" *ngIf="sharedAccordionFunctionality.customFieldsDocuments[0] != undefined">
-                    <div class="row my-2 py-2" id="document-row" *ngFor="let fieldcode of sharedAccordionFunctionality.customFieldsDocuments;let i = index">
+                <div id="table-body" class="my-2" *ngIf="unArchivedCustomDocuments[0] != undefined">
+                    <div class="row my-2 py-2" id="document-row" *ngFor="let fieldcode of unArchivedCustomDocuments;let i = index">
                         <div id="document" class="col-12 col-md-6 col-lg-6" >
                             <h3>{{fieldcode.name}}</h3>
                             <div class="col-12" id="fileName" *ngIf="getDocumentName(fieldcode.name) as document;else NoFile" id="fileName">

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.ts
@@ -36,6 +36,8 @@ export class AccordionDocumentsCustomDocumentsComponent {
   uploadButtonIndex: number = 0;
   documentFormProgress: number = 0;
   documentId: number = 0;
+  fieldCodeStatus: any = -1;
+  customDocumentsCategory: number = 3;
   selectedFile !: File;
   documentsFileName: string = "";
   DocumentTypeName: string = "";
@@ -119,7 +121,6 @@ export class AccordionDocumentsCustomDocumentsComponent {
   getDocumentFieldCodes() {
     this.customFieldService.getAllFieldCodes().subscribe({
       next: data => {
-        this.sharedAccordionFunctionality.customFieldsDocuments = data.filter((data: CustomField) => data.category === this.sharedAccordionFunctionality.category[3].id);
         this.checkCustomDocumentsInformation();
         this.checkArchived(data);
       }
@@ -130,7 +131,7 @@ export class AccordionDocumentsCustomDocumentsComponent {
     var index = 0;
     fields.forEach((field: { category: number; status: any; }) => {
       index++;
-      if (field.status == -1 && field.category == 3) {
+      if (this.fieldCodeStatus == field.status && field.category == 3) {
         fields.splice(index, 1);
       }
       else {

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.ts
@@ -131,7 +131,7 @@ export class AccordionDocumentsCustomDocumentsComponent {
     var index = 0;
     fields.forEach((field: { category: number; status: any; }) => {
       index++;
-      if (this.fieldCodeStatus == field.status && field.category == 3) {
+      if (this.fieldCodeStatus == field.status && this.customDocumentsCategory == field.category) {
         fields.splice(index, 1);
       }
       else {

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.ts
@@ -13,7 +13,6 @@ import { NavService } from 'src/app/services/shared-services/nav-service/nav.ser
 import { CookieService } from 'ngx-cookie-service';
 import { MatTableDataSource } from '@angular/material/table';
 import { FileCategory } from 'src/app/models/hris/constants/documents.contants';
-import { ManageFieldCodeComponent } from 'src/app/components/hris/custom-fields/manage-field-code/manage-field-code.component';
 
 @Component({
   selector: 'app-accordion-additional-documents',
@@ -22,7 +21,6 @@ import { ManageFieldCodeComponent } from 'src/app/components/hris/custom-fields/
 })
 export class AccordionDocumentsCustomDocumentsComponent {
   @Input() employeeProfile!: EmployeeProfile;
-  @Input() archivedField!: { ArchivedField: ManageFieldCodeComponent };
 
   screenWidth = window.innerWidth;
 

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.ts
@@ -13,6 +13,7 @@ import { NavService } from 'src/app/services/shared-services/nav-service/nav.ser
 import { CookieService } from 'ngx-cookie-service';
 import { MatTableDataSource } from '@angular/material/table';
 import { FileCategory } from 'src/app/models/hris/constants/documents.contants';
+import { ManageFieldCodeComponent } from 'src/app/components/hris/custom-fields/manage-field-code/manage-field-code.component';
 
 @Component({
   selector: 'app-accordion-additional-documents',
@@ -21,6 +22,7 @@ import { FileCategory } from 'src/app/models/hris/constants/documents.contants';
 })
 export class AccordionDocumentsCustomDocumentsComponent {
   @Input() employeeProfile!: EmployeeProfile;
+  @Input() archivedField!: { ArchivedField: ManageFieldCodeComponent };
 
   screenWidth = window.innerWidth;
 
@@ -30,6 +32,7 @@ export class AccordionDocumentsCustomDocumentsComponent {
   }
 
   fileCategories = [];
+  unArchivedCustomDocuments: any = [];
   roles: string[] = [];
   isLoadingUpload: boolean = false;
   uploadButtonIndex: number = 0;
@@ -120,6 +123,21 @@ export class AccordionDocumentsCustomDocumentsComponent {
       next: data => {
         this.sharedAccordionFunctionality.customFieldsDocuments = data.filter((data: CustomField) => data.category === this.sharedAccordionFunctionality.category[3].id);
         this.checkCustomDocumentsInformation();
+        this.checkArchived(data);
+      }
+    })
+  }
+
+  checkArchived(fields: any) {
+    var index = 0;
+    fields.forEach((field: { category: number; status: any; }) => {
+      index++;
+      if (field.status == -1 && field.category == 3) {
+        fields.splice(index, 1);
+      }
+      else {
+        this.unArchivedCustomDocuments.push(field);
+        this.unArchivedCustomDocuments = this.unArchivedCustomDocuments.filter((field: any) => field.category == this.sharedAccordionFunctionality.category[3].id)
       }
     })
   }

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-documents/accordion-additional-documents/accordion-additional-documents.component.ts
@@ -30,7 +30,7 @@ export class AccordionDocumentsCustomDocumentsComponent {
   }
 
   fileCategories = [];
-  unArchivedCustomDocuments: any = [];
+  unarchivedCustomDocuments: any = [];
   roles: string[] = [];
   isLoadingUpload: boolean = false;
   uploadButtonIndex: number = 0;
@@ -134,8 +134,8 @@ export class AccordionDocumentsCustomDocumentsComponent {
         fields.splice(index, 1);
       }
       else {
-        this.unArchivedCustomDocuments.push(field);
-        this.unArchivedCustomDocuments = this.unArchivedCustomDocuments.filter((field: any) => field.category == this.sharedAccordionFunctionality.category[3].id)
+        this.unarchivedCustomDocuments.push(field);
+        this.unarchivedCustomDocuments = this.unarchivedCustomDocuments.filter((field: any) => field.category == this.sharedAccordionFunctionality.category[3].id)
       }
     })
   }


### PR DESCRIPTION
Description: When Documents are archived in system settings > Custom Field Management they are supposed to disappear on the accordion and when unarchived appear again on the accordion


**Archived Documents:**
![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/0e7bf55c-91f5-44b9-9d92-85cf4c20c670)


**No Documents Displayed when custom documents is archived:**
![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/273360a3-3a45-44b6-a81d-6bfb49949741)


**Custom Documents not archived:**
![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/ea71ab43-e031-4075-8786-02dfa8b83930)


**Custom Document Field Showing when not archived:**
![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/24f95870-98f0-46b0-a4bc-c26e1e9c6c29)

