### PR TITLE
Updated uploads to take in PDF, PNG and JPG with helper text

### DIFF
--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.css
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.css
@@ -56,6 +56,11 @@
   color: grey;
 }
 
+#helperText {
+  color: grey;
+  font-weight:500;
+}
+
 #svg-icon-w #icon-w {
   fill: white;
 }

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.html
@@ -77,7 +77,7 @@
                     </svg> Upload
                   </button>
                 </div>
-                <input hidden type="file" (change)="uploadDocument($event)" accept=".pdf,.png,.jpg,.jpeg"
+                <input hidden type="file" (change)="uploadDocument($event)" accept=".pdf, .png, .jpg, .jpeg"
                   [id]="i + '-administrative-document'">
               </div>
             </div>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.html
@@ -24,6 +24,7 @@
           <div *ngFor="let category of sharedAccordionFunctionality.fileAdminCategories;let i = index" class="row my-2 py-2" id="document-row">
             <div id="document" class="col-12 col-md-6 col-lg-7">
               <h3>{{category}}</h3>
+              <div *ngIf="category == 'Written Approval of Offer'" id="helperText" class="mb-2">PDF,PNG,JPG</div>
               <div class="col-12" *ngIf="getFileName(i) as document;else NoFile" id="fileName">
                 <p>{{document.fileName}}</p>
               </div>
@@ -76,7 +77,7 @@
                     </svg> Upload
                   </button>
                 </div>
-                <input hidden type="file" (change)="uploadDocument($event)" accept=".pdf"
+                <input hidden type="file" (change)="uploadDocument($event)" accept=".pdf,.png,.jpg,.jpeg"
                   [id]="i + '-administrative-document'">
               </div>
             </div>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.html
@@ -23,8 +23,9 @@
         <div id="table-body" class="my-2">
           <div *ngFor="let category of sharedAccordionFunctionality.fileAdminCategories;let i = index" class="row my-2 py-2" id="document-row">
             <div id="document" class="col-12 col-md-6 col-lg-7">
-              <h3>{{category}}</h3>
+              <h3 class="mt-2">{{category}}</h3>
               <div *ngIf="category == 'Written Approval of Offer'" id="helperText" class="mb-2">PDF,PNG,JPG</div>
+              <div *ngIf="category != 'Written Approval of Offer'" id="helperText" class="mb-2">PDF</div>
               <div class="col-12" *ngIf="getFileName(i) as document;else NoFile" id="fileName">
                 <p>{{document.fileName}}</p>
               </div>
@@ -32,7 +33,7 @@
                 <p>Download & upload document here</p>
               </ng-template>
             </div>
-            <div ngClass="{{ screenWidth >= 1200 ? 'pt-4 padding-row-buttons' : ''}}" class="col-12 col-md-4 col-lg-5 py-2">
+            <div ngClass="{{ screenWidth >= 1200 ? 'pt-4 padding-row-buttons' : ''}}" class="col-12 col-md-4 col-lg-5 py-2 mt-2">
               <div class="row">
                 <div id="actionCellDownload" class="col-12 col-md-auto mb-2">
                   <button *ngIf="disableDownload(i);else DisabledDownload" mat-button color="primary" (click)="downloadDocument($event)" [disabled]="!disableDownload(i)"
@@ -77,7 +78,7 @@
                     </svg> Upload
                   </button>
                 </div>
-                <input hidden type="file" (change)="uploadDocument($event)" accept=".pdf, .png, .jpg"
+                <input hidden type="file" (change)="uploadDocument($event, category)" [accept]="getAcceptedFileTypes(category)"
                   [id]="i + '-administrative-document'">
               </div>
             </div>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.html
@@ -77,7 +77,7 @@
                     </svg> Upload
                   </button>
                 </div>
-                <input hidden type="file" (change)="uploadDocument($event)" accept=".pdf, .png, .jpg, .jpeg"
+                <input hidden type="file" (change)="uploadDocument($event)" accept=".pdf, .png, .jpg"
                   [id]="i + '-administrative-document'">
               </div>
             </div>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.ts
@@ -35,7 +35,7 @@ export class AccordionAdministrativeDocumentsComponent {
   selectedFile !: File;
   roles: string[] = [];
   isLoadingUpload: boolean = false;
-  allowedTypes = ['application/pdf'];
+  allowedTypes = ['application/pdf', 'image/png', 'image/jpeg'];
   showConfirmDialog: boolean = false;
   dialogTypeData!: Dialog;
   documentExists: boolean = false;
@@ -101,7 +101,7 @@ export class AccordionAdministrativeDocumentsComponent {
     if (this.allowedTypes.includes(this.selectedFile.type)) {
       this.uploadProfileDocument();
     } else {
-      this.snackBarService.showSnackbar("Please upload a PDF", "snack-error");
+      this.snackBarService.showSnackbar("Please upload a PDF, PNG or JPG", "snack-error");
       this.isLoadingUpload = false;
     }
   }

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.ts
@@ -35,7 +35,7 @@ export class AccordionAdministrativeDocumentsComponent {
   selectedFile !: File;
   roles: string[] = [];
   isLoadingUpload: boolean = false;
-  allowedTypes = ['application/pdf', 'image/png', 'image/jpeg'];
+  allowedTypes = ['application/pdf', 'image/png', 'image/jpg'];
   showConfirmDialog: boolean = false;
   dialogTypeData!: Dialog;
   documentExists: boolean = false;

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-administrative-documents/accordion-administrative-documents.component.ts
@@ -57,28 +57,28 @@ export class AccordionAdministrativeDocumentsComponent {
     this.getEmployeeDocuments();
 
   }
-
+  
   downloadFile(base64String: string, fileName: string) {
     const commaIndex = base64String.indexOf(',');
     if (commaIndex !== -1) {
       base64String = base64String.slice(commaIndex + 1);
     }
-
+    
     const byteString = atob(base64String);
     const arrayBuffer = new ArrayBuffer(byteString.length);
     const intArray = new Uint8Array(arrayBuffer);
-
+    
     for (let i = 0; i < byteString.length; i++) {
       intArray[i] = byteString.charCodeAt(i);
     }
-
+    
     const blob = new Blob([arrayBuffer], { type: 'application/pdf' });
     const link = document.createElement('a');
     link.href = window.URL.createObjectURL(blob);
     link.download = fileName;
     link.click();
   }
-
+  
   captureUploadIndex(event: any) {
     this.uploadButtonIndex = event.srcElement.parentElement.id;
     const inputField = document.getElementById(`${this.uploadButtonIndex}-administrative-document`) as HTMLInputElement;
@@ -93,15 +93,23 @@ export class AccordionAdministrativeDocumentsComponent {
       inputField.click();
     }
   }
+  
+  getAcceptedFileTypes(category: string): string {
+    return category === 'Written Approval of Offer' ? '.pdf, .png, .jpg, .jpeg' : '.pdf';
+  }
 
-  uploadDocument(event: any) {
+  uploadDocument(event: any, category: string) {
     this.isLoadingUpload = true;
     this.selectedFile = event.target.files[0];
     this.documentsFileName = this.selectedFile.name;
-    if (this.allowedTypes.includes(this.selectedFile.type)) {
+    
+    const allowedTypes = this.getAcceptedFileTypes(category).split(', ').map(type => type.replace('.', ''));
+    const fileType = this.selectedFile.type.split('/').pop()?.toLowerCase();
+    
+    if (fileType && allowedTypes.includes(fileType)) {
       this.uploadProfileDocument();
     } else {
-      this.snackBarService.showSnackbar("Please upload a PDF, PNG or JPG", "snack-error");
+      this.snackBarService.showSnackbar("Please upload the correct file type", "snack-error");
       this.isLoadingUpload = false;
     }
   }


### PR DESCRIPTION
**Updated the written approval of offer to accept more document types:**

- Added helper text like on the design:

![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/ebd0f7b6-0f00-497b-9a98-6986a0a13dfe)

- Uploaded PDF:

![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/1e784af6-fb95-4cb6-9b29-4fb1061346b3)

- Uploaded PNG:

![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/62c237d3-291c-45e0-b0ca-13032ba7c301)

- Uploaded JPG:

![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/4a6ee005-33f0-4e76-a33b-fd7fb4fca47d)

- When uploading the wrong file type:

![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/23edcedd-877d-4bde-8e7f-9f8ed8c9fabb)
