### PR TITLE
fixed object object error

### DIFF
--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-summary-qualifications/accordion-career-summary-qualifications.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-summary-qualifications/accordion-career-summary-qualifications.component.ts
@@ -43,11 +43,9 @@ export class CareerSummaryQualificationsComponent {
   isDisabledDownload: boolean = true;
 
   fileName: string = '';
-  filePreview: string | ArrayBuffer | null = null;
   base64File: string = "";
   fileUrl: string = '';
   proofOfQualificationFinal: string = '';
-
 
   ngOnInit() {
     this.fetchQualificationsById();
@@ -210,7 +208,6 @@ export class CareerSummaryQualificationsComponent {
     fieldNames.forEach(fieldName => {
       let control: AbstractControl<any, any> | null = null;
       control = this.sharedAccordionFunctionality.personalDetailsForm.get(fieldName);
-
       if (control) {
         switch (this.sharedPropertyAccessService.checkPermission(table, fieldName)) {
           case PropertyAccessLevel.none:

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-summary-qualifications/accordion-career-summary-qualifications.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-summary-qualifications/accordion-career-summary-qualifications.component.ts
@@ -130,7 +130,7 @@ export class CareerSummaryQualificationsComponent {
           this.sharedAccordionFunctionality.totalCareerProgress();
         },
         error: (error) => {
-          this.snackBarService.showSnackbar(error.error, "snack-error");
+          this.snackBarService.showSnackbar("Please upload a qualification document", "snack-error");
         },
         complete: () => this.fetchQualificationsById()
       });


### PR DESCRIPTION
Fixed a object object error that was being throw when you try and save the qualifications accordion without uploading a doc

- Snackbar now clarifies that you need a document or you need to fill in missing fields depending on the situation