### PR TITLE
Updated the delete buttons and form design for Work Experience and Certification accordions

### DIFF
--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.css
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.css
@@ -45,8 +45,8 @@ mat-icon{
     align-items: center;
 }
 
-#experience-remove {
-    margin-left: 720px;
+#experience-remove-new {
+    justify-content: end;
 }
 
 .icon-color{

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.html
@@ -22,13 +22,13 @@
                                 <div id="form-wrapper" class="col-12">
                                     <div class="row">
                                     <div class="d-flex">
-                                        <div class="row d-block">
+                                        <div class="col-6">
                                             <div class="experience-header">
                                                 <h3 class="mb-1" id="clientNameHeading">{{sharedAccordionFunctionality.workExperience[i].clientName}} | {{ formatDate(sharedAccordionFunctionality.workExperience[i].startDate) }}</h3>
                                             </div>
                                         </div>
-                                        <div class="row d-block" id="experience-remove">
-                                            <div class="experience-header" *ngIf="editWorkExperience">
+                                        <div class="col-6 justify-content-end">
+                                            <div class="experience-header"id="experience-remove-new" *ngIf="editWorkExperience">
                                                 <button mat-button id="delete-button" (click)="showDialog('update',i)">
                                                     <mat-icon class="icon-color mb-1">delete_outline</mat-icon>Delete
                                                 </button>
@@ -152,7 +152,7 @@
 
                         <div *ngFor="let experiences of sharedAccordionFunctionality.newWorkExperiences; let i = index" class="row">
                             <div class="row d-block">
-                                <div class="experience-header" *ngIf="addingWorkExperience">
+                                <div class="experience-header" id="experience-remove-new" *ngIf="addingWorkExperience">
                                     <button mat-button id="delete-button" (click)="showDialog('new',i)">
                                         <mat-icon class="icon-color mb-1">delete_outline</mat-icon>Delete
                                     </button>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.css
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.css
@@ -106,13 +106,33 @@ mat-icon{
 }
 
 .icon-color{
-    color: red;
+    color: rgb(184, 2, 2);
 }
 
 .certificate-header h2 {
     margin: 0; 
     margin-right: 8px;
     gap: 20px;
+}
+
+.certificate-header {
+    display: flex;
+    align-items: center;
+}
+
+#certificateNameHeading {
+    font-weight: 500;
+}
+
+#delete-button {
+    border: none;
+    border-radius: 2rem;
+    color: rgb(184, 2, 2);
+    width: 120px;
+}
+
+#certificate-remove-new {
+    justify-content: end;
 }
 
 .download-document , .add-qualification , #download-document-button {

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.html
@@ -7,10 +7,6 @@
                 <mat-panel-title>
                     Certificates
                 </mat-panel-title>
-                <!-- <mat-panel-description *ngIf="certificateInformationProgress != 100" class="pe-0 pe-md-5">
-                    <mat-icon class="mx-1">error</mat-icon>
-                    <span class="d-none d-md-block d-lg-block">Missing information</span>
-                </mat-panel-description> -->
             </mat-expansion-panel-header>
             <div class="col-12">
                 <div class="row">
@@ -24,16 +20,18 @@
                         <div *ngFor="let certificate of sharedAccordionFunctionality.employeeCertificates; let i = index" class="col-12">
                             <div id="form-wrapper" class="col-12">
                                 <div class="row">
-                                    <div class="row d-block">
-                                        <div class="certificate-header" *ngIf="editCertificate">
-                                            <h3 class="mb-2">{{copyOfCertificates[i].certificateName}}</h3>
-                                            <mat-icon class="icon-color mb-2"
-                                                (click)="showDialog('update',i)">delete_outline</mat-icon>
+                                    <div class="d-flex">
+                                        <div class="col-6">
+                                            <div class="certificate-header">
+                                                <h3 class="mb-1" id="certificateNameHeading">{{sharedAccordionFunctionality.employeeCertificates[i].certificateName}}</h3>
+                                            </div>
                                         </div>
-                                    </div>
-                                    <div class="row d-block">
-                                        <div class="certificate-header" *ngIf="!editCertificate">
-                                            <h3 class="mb-1">{{sharedAccordionFunctionality.employeeCertificates[i].certificateName}}</h3>
+                                        <div class="col-6 justify-content-end">
+                                            <div class="certificate-header" id="certificate-remove-new" *ngIf="editCertificate">
+                                                <button mat-button id="delete-button" (click)="showDialog('update',i)">
+                                                    <mat-icon class="icon-color mb-1">delete_outline</mat-icon>Delete
+                                                </button>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="col-12 col-md-6 my-2">
@@ -112,7 +110,7 @@
                                             Download
                                         </button>
                                     </div>
-                                    <div id="actionCellUpload" class="col-12 col-md-auto" *ngIf="editCertificate">
+                                    <div id="actionCellUpload" class="col-12 col-md-auto mb-1" *ngIf="editCertificate">
                                         <button type="file" mat-button color="primary"
                                             (click)="uploadCertificateFile.click()" accept=".pdf"
                                             [ngClass]="screenWidth <= 767 ?'upload-download-button':''">
@@ -129,14 +127,16 @@
                                         <input type="file" #uploadCertificateFile
                                             (change)="onFileChange($event, i,'update')" hidden accept=".pdf">
                                     </div>
+                                    <hr>
                                 </div>
                             </div>
                         </div>
                         <div *ngFor="let newCertificate of newCertificates; let i = index" class="row">
                             <div class="row d-block">
-                                <div class="certificate-header" *ngIf="addingCertificate">
-                                    <h3 class=" mb-0">Remove new certificate</h3>
-                                    <mat-icon class="icon-color" (click)="showDialog('new',i)">delete_outline</mat-icon>
+                                <div class="certificate-header" id="certificate-remove-new" *ngIf="addingCertificate">
+                                    <button mat-button id="delete-button" (click)="showDialog('new',i)">
+                                        <mat-icon class="icon-color mb-1">delete_outline</mat-icon>Delete
+                                    </button>
                                 </div>
                             </div>
                             <div class="row d-block">
@@ -228,7 +228,7 @@
                             <h2>Add Another New Certificate Here</h2>
                             <button mat-button id="add-another-button" [disabled]="editCertificate" type="submit"
                                 (click)="addNewCertificate()">
-                                <mat-icon>add</mat-icon> Add Another Experience
+                                <mat-icon>add</mat-icon> Add Another Certificate
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
_**Ticket Details:**_

- Updated the styling and implemented the design for delete buttons from Figma
- Added lines under forms to be able to distinguish between forms
- (This has been implemented for both Work Experience and Certificate accordions)

1. **Certificates Accordion:**

![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/3943b103-1d56-48fc-929b-67871709f37c)
![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/661682a3-8866-4ed0-84b2-59d322536d37)
![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/507a0cca-9792-494e-98cc-9c7bb2111511)

2. **Work Experience Accordion:**

![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/b270d691-7c83-482c-b8ce-ff685368a24f)
![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/fc5f8b3c-afae-454b-b189-55c476984c96)
![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/81bb8af7-cd99-46f2-8554-bd135396ec0a)

_**Tested this and it works on other employees as well:**_