### PR TITLE
Juanro/fix required missing info 

### DIFF
--- a/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
+++ b/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
@@ -283,29 +283,33 @@ export class SharedAccordionFunctionality {
   }
   
   checkAddressFormProgress() {
-    let filledCount = 0;
-    const formControls = this.addressDetailsForm.controls;
-    let totalFields = 0;
-    if (this.physicalEqualPostal) {
-      totalFields = (Object.keys(this.addressDetailsForm.controls).length) / 2;
-    }
-    else if (!this.physicalEqualPostal) {
-      totalFields = (Object.keys(this.addressDetailsForm.controls).length);
-    }
+  let filledCount = 0;
+  let requiredFields = 0;
+  const formControls = this.addressDetailsForm.controls;
 
-    for (const controlName in formControls) {
-      if (formControls.hasOwnProperty(controlName)) {
-        const control = formControls[controlName];
-        if (this.physicalEqualPostal && controlName.includes("physical") && control.value != null && control.value != " " && control.value != "") {
-          filledCount++;
-        }
-        else if (!this.physicalEqualPostal && control.value != null && control.value != " " && control.value != "") {
+  for (const controlName in formControls) {
+    if (formControls.hasOwnProperty(controlName)) {
+      const control = formControls[controlName]; 
+      let isRequired = false;
+      if (control.validator) {
+        const validator = control.validator({} as AbstractControl); 
+        isRequired = validator && validator['required'] ? true : false; 
+      }
+      if (isRequired) {
+        requiredFields++;
+        if (control.value != null && control.value !== '') {
           filledCount++;
         }
       }
     }
-    this.addressFormProgress = Math.round((filledCount / totalFields) * 100);
   }
+  if (requiredFields === 0) {
+    this.addressFormProgress = 100;
+  } else {
+    this.addressFormProgress = Math.round((filledCount / requiredFields) * 100);
+  }
+}
+
 
   checkAdditionalFormProgress() {
     let filledCount = 0;

--- a/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
+++ b/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
@@ -11,7 +11,7 @@ import { EmployeeData } from 'src/app/models/hris/employee-data.interface';
 import { CustomField } from 'src/app/models/hris/custom-field.interface';
 import { category } from 'src/app/models/hris/constants/fieldcodeCategory.constants';
 import { dataTypes } from 'src/app/models/hris/constants/types.constants';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { SharedPropertyAccessService } from 'src/app/services/hris/shared-property-access.service';
 import { AdminDocuments } from 'src/app/models/hris/constants/admin-documents.component';
 import { EmployeeDocumentsTypes } from 'src/app/models/hris/constants/employee-documents.constants';
@@ -256,19 +256,32 @@ export class SharedAccordionFunctionality {
 
   checkContactFormProgress() {
     let filledCount = 0;
+    let requiredFields = 0;
     const formControls = this.employeeContactForm.controls;
-    const totalFields = Object.keys(this.employeeContactForm.controls).length;
+  
     for (const controlName in formControls) {
       if (formControls.hasOwnProperty(controlName)) {
         const control = formControls[controlName];
-        if (control.value != null && control.value != '') {
-          filledCount++;
+        let isRequired = false;
+        if (control.validator) {
+          const validator = control.validator({} as AbstractControl);
+          isRequired = validator && validator['required'] ? true : false;
+        }
+        if (isRequired) {
+          requiredFields++;
+          if (control.value != null && control.value !== '') {
+            filledCount++;
+          }
         }
       }
     }
-    this.contactFormProgress = Math.round((filledCount / totalFields) * 100);
+    if (requiredFields === 0) {
+      this.contactFormProgress = 100;
+    } else {
+      this.contactFormProgress = Math.round((filledCount / requiredFields) * 100);
+    }
   }
-
+  
   checkAddressFormProgress() {
     let filledCount = 0;
     const formControls = this.addressDetailsForm.controls;


### PR DESCRIPTION
![image](https://github.com/RetroRabbit/RGO-Client/assets/156077669/548f3dd6-9717-4241-9b31-6ad91ed302e6)
Home number is not a required field so it no longer throws missing info if it s not filled in

![image](https://github.com/RetroRabbit/RGO-Client/assets/156077669/8618db29-100a-4358-888b-e5cf3e674801)


The contact and address details now only show missing information if a required field is missing data