### PR TITLE
Career summary progress Bug Fix

### DIFF
--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-summary-qualifications/accordion-career-summary-qualifications.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-summary-qualifications/accordion-career-summary-qualifications.component.ts
@@ -119,9 +119,6 @@ export class CareerSummaryQualificationsComponent {
       const qualificationObservable = updatedQualification.id > 0
         ? this.employeeQualificationsService.updateEmployeeQualification(updatedQualification, updatedQualification.id)
         : this.employeeQualificationsService.saveEmployeeQualification(updatedQualification);
-
-      this.sharedAccordionFunctionality.calculateQaulificationProgress();
-      this.sharedAccordionFunctionality.totalCareerProgress();
       qualificationObservable.subscribe({
         next: () => {
           this.snackBarService.showSnackbar(

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.ts
@@ -271,7 +271,6 @@ export class AccordionCareerWorkExperienceComponent {
         this.getWorkExperience();
         this.sharedAccordionFunctionality.calculateCareerWorkExperienceFormProgress();
         this.sharedAccordionFunctionality.totalCareerProgress();
-
       },
       error: () => {
         this.snackBarService.showSnackbar("Unable to update all fields", "snack-error");

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.ts
@@ -79,7 +79,6 @@ export class AccordionCareerWorkExperienceComponent {
     this.workExperienceService.getWorkExperience(this.employeeProfile.id as number).subscribe({
       next: (data) => {
         this.sharedAccordionFunctionality.workExperience = data;
-        this.sharedAccordionFunctionality.workExpereinceFormFields = this.sharedAccordionFunctionality.workExpereinceFormFields * this.sharedAccordionFunctionality.workExperience.length;
         this.sharedAccordionFunctionality.calculateCareerWorkExperienceFormProgress();
         this.sharedAccordionFunctionality.totalCareerProgress();
       },

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.ts
@@ -270,6 +270,9 @@ export class AccordionCareerWorkExperienceComponent {
         this.snackBarService.showSnackbar("Work experience info updated", "snack-success");
         this.hasUpdatedWorkExperience = true;
         this.getWorkExperience();
+        this.sharedAccordionFunctionality.calculateCareerWorkExperienceFormProgress();
+        this.sharedAccordionFunctionality.totalCareerProgress();
+
       },
       error: () => {
         this.snackBarService.showSnackbar("Unable to update all fields", "snack-error");

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.html
@@ -131,7 +131,7 @@
                                             Upload
                                         </button>
                                         <input type="file" #uploadCertificateFile
-                                            (change)="onFileChange($event, i,'update')"  hidden accept=".pdf">
+                                            (change)="onFileChange($event, i,'update')" hidden accept=".pdf">
                                     </div>
                                     <hr>
                                 </div>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.html
@@ -94,6 +94,12 @@
                                         <h3 class='ml-1' [ngStyle]="{'color': editCertificate ? 'black' : 'grey'}">Proof
                                             of certificate</h3>
                                     </div>
+                                    <div>
+                                    <div
+                                        [ngStyle]="{'color' : editCertificate ? 'black' :'grey'}">
+                                        {{ sharedAccordionFunctionality.employeeCertificates[i].documentName}}
+                                    </div>
+                                </div>
                                     <div id="actionCellDownload" class="col-12 col-md-auto mb-2">
                                         <button mat-button color="primary"
                                             (click)="downloadFile(sharedAccordionFunctionality.employeeCertificates[i].certificateDocument, sharedAccordionFunctionality.employeeCertificates[i].documentName)"
@@ -125,7 +131,7 @@
                                             Upload
                                         </button>
                                         <input type="file" #uploadCertificateFile
-                                            (change)="onFileChange($event, i,'update')" hidden accept=".pdf">
+                                            (change)="onFileChange($event, i,'update')"  hidden accept=".pdf">
                                     </div>
                                     <hr>
                                 </div>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.ts
@@ -274,6 +274,7 @@ export class AccordionCertificatesComponent {
       this.fileUploaded = true;
       const file = event.target.files[0];
       this.fileConverter(file, index, newOrUpdate);
+      this.certificateFileName = file.name;
     }
   }
 

--- a/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
+++ b/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
@@ -400,15 +400,11 @@ export class SharedAccordionFunctionality {
         }
       }
       ));
-
-      const FilledCount = this.filteredFilledWorkExp.length;
-      if (FilledCount == 0 || this.workExpereinceFormFields == 0) {
-        this.workExpFormProgress = 0;
-      }
-      else {
-        this.workExpFormProgress = Math.round((FilledCount / this.workExpereinceFormFields) * 100);
-      }
     }
+
+    const FilledCount = this.filteredFilledWorkExp.length;
+    this.workExpFormProgress = FilledCount === 0 || this.workExpereinceFormFields == 0 ? 0
+      : Math.round((FilledCount / this.workExpereinceFormFields) * 100);
   }
 
   calculateCareerCertficatesFormProgress() {
@@ -426,7 +422,7 @@ export class SharedAccordionFunctionality {
       }
 
       targetCertficates.filter((element: any) => {
-        const { employeeId, id, ...samplearray } = element;
+        const { employeeId, id, certificateDocument, ...samplearray } = element;
         newTargetCertficates.push(samplearray);
       });
 
@@ -439,12 +435,8 @@ export class SharedAccordionFunctionality {
     }
 
     const FilledCount = this.filteredFilledCerificate.length;
-    if (FilledCount == 0 || this.employeeCertificatesFields == 0) {
-      this.certificateformProgress = 0;
-    }
-    else {
-      this.certificateformProgress = Math.round((FilledCount / this.employeeCertificatesFields) * 100);
-    }
+    this.employeeCertificatesFields = FilledCount === 0 || this.workExpereinceFormFields == 0 ? 0
+      : Math.round((FilledCount / this.employeeCertificatesFields) * 100);
   }
 
   calculatesalaryDetails() {
@@ -460,6 +452,7 @@ export class SharedAccordionFunctionality {
       }
     }
     this.salaryDetailsFormProgress = Math.round((filledCount / totalFields) * 100);
+    console.log("salary perc:", this.salaryDetailsFormProgress);
   }
 
   totalProfileProgress() {

--- a/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
+++ b/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
@@ -435,7 +435,7 @@ export class SharedAccordionFunctionality {
     }
 
     const FilledCount = this.filteredFilledCerificate.length;
-    this.employeeCertificatesFields = FilledCount === 0 || this.workExpereinceFormFields == 0 ? 0
+    this.certificateformProgress = FilledCount === 0 || this.workExpereinceFormFields == 0 ? 0
       : Math.round((FilledCount / this.employeeCertificatesFields) * 100);
   }
 
@@ -452,7 +452,6 @@ export class SharedAccordionFunctionality {
       }
     }
     this.salaryDetailsFormProgress = Math.round((filledCount / totalFields) * 100);
-    console.log("salary perc:", this.salaryDetailsFormProgress);
   }
 
   totalProfileProgress() {

--- a/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
+++ b/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
@@ -402,7 +402,7 @@ export class SharedAccordionFunctionality {
       ));
 
       const FilledCount = this.filteredFilledWorkExp.length;
-      if (FilledCount == 0 && this.workExpereinceFormFields == 0) {
+      if (FilledCount == 0 || this.workExpereinceFormFields == 0) {
         this.workExpFormProgress = 0;
       }
       else {
@@ -439,7 +439,7 @@ export class SharedAccordionFunctionality {
     }
 
     const FilledCount = this.filteredFilledCerificate.length;
-    if (FilledCount == 0 && this.employeeCertificatesFields == 0) {
+    if (FilledCount == 0 || this.employeeCertificatesFields == 0) {
       this.certificateformProgress = 0;
     }
     else {
@@ -468,8 +468,13 @@ export class SharedAccordionFunctionality {
   }
 
   totalCareerProgress() {
-    this.careerFormProgress = Math.floor((this.additionalCareerFormProgress + this.qaulificationFormProgress + this.certificateformProgress + this.workExpFormProgress + this.salaryDetailsFormProgress) / 5);
-    this.updateCareer.emit(this.careerFormProgress);
+    if (this.additionalCareerFormProgress == Infinity) {
+      this.careerFormProgress = Math.floor((this.qaulificationFormProgress + this.certificateformProgress + this.workExpFormProgress + this.salaryDetailsFormProgress) / 4);
+    }
+    else {
+      this.careerFormProgress = Math.floor((this.additionalCareerFormProgress + this.qaulificationFormProgress + this.certificateformProgress + this.workExpFormProgress + this.salaryDetailsFormProgress) / 5);
+      this.updateCareer.emit(this.careerFormProgress);
+    }
   }
 
   totalDocumentsProgress() {

--- a/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
+++ b/src/app/components/hris/employees/employee-profile/shared-accordion-functionality.ts
@@ -125,8 +125,8 @@ export class SharedAccordionFunctionality {
   salaryDetailsFormProgress: number = 0;
   additionalCareerFormProgress: number = 0;
 
-  workExpereinceFormFields: number = 6;
-  employeeCertificatesFields: number = 4;
+  workExpereinceFormFields: number = 0;
+  employeeCertificatesFields: number = 0;
 
   genders = genders;
   races = races;
@@ -379,13 +379,13 @@ export class SharedAccordionFunctionality {
     let targetWorkExp: any = [];
     let newTargetWorkExp: any = [];
     this.filteredFilledWorkExp.length = 0;
+    this.workExpereinceFormFields = 6 * this.workExperience.length;
 
     if (this.workExperience.length === 0) {
       this.workExpereinceFormFields = 0;
       this.filteredFilledWorkExp.length = 0;
     }
     else {
-
       for (const element of this.workExperience) {
         targetWorkExp.push(element);
       }
@@ -411,6 +411,7 @@ export class SharedAccordionFunctionality {
     let targetCertficates: any = [];
     let newTargetCertficates: any = [];
     this.filteredFilledCerificate.length = 0;
+    this.employeeCertificatesFields = 4 * this.employeeCertificates.length;
 
     if (this.employeeCertificates.length === 0) {
       this.employeeCertificatesFields = 0;
@@ -435,7 +436,7 @@ export class SharedAccordionFunctionality {
     }
 
     const FilledCount = this.filteredFilledCerificate.length;
-    this.certificateformProgress = FilledCount === 0 || this.workExpereinceFormFields == 0 ? 0
+    this.certificateformProgress = FilledCount === 0 || this.employeeCertificatesFields == 0 ? 0
       : Math.round((FilledCount / this.employeeCertificatesFields) * 100);
   }
 


### PR DESCRIPTION
The bug that was fixed: Career progress would go into  "**Infinity**" and progress calculation would run over **100%.**

Description of Fix: Career progress works perfectly for all accordions and updates the overall progress as well.
![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/c8de7c63-6c2f-4c9b-98db-b5b7ae69e73c)

 **Work experience and certificates is empty:**
![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/9c6aff15-531e-4bdc-b76e-989e83066fec)

**One of the accordions are empty:**
![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/a969f7b0-eec9-4030-93dc-85f2a804c0bb)

![image](https://github.com/RetroRabbit/RGO-Client/assets/156072510/435d2486-e2c9-426a-92bb-445dd648c0e2)
