### PR TITLE
Default profile image loaded when creating new employee

### DIFF
--- a/src/app/components/ats/candidates/new-candidate/new-candidate.component.ts
+++ b/src/app/components/ats/candidates/new-candidate/new-candidate.component.ts
@@ -43,7 +43,7 @@ export class NewCandidateComponent {
   schools: string[] = schools.map((school) => school.value);
   qualifications: string[] = qualifications.map((qualification) => qualification.value);
   years: number[] = [];
-  imagePreview: string | ArrayBuffer | null = null;
+  imagePreview: string = '';
   previewImage: string = '';
   imageName: string = '';
   imageUrl: string = '';

--- a/src/app/components/hris/employees/new-employee/new-employee.component.ts
+++ b/src/app/components/hris/employees/new-employee/new-employee.component.ts
@@ -77,7 +77,7 @@ export class NewEmployeeComponent implements OnInit {
   provinces: string[] = [];
   countries: string[] = [];
   cities: string[] = [];
-  imagePreview: string | ArrayBuffer | null = null;
+  imagePreview: string = '';
   previewImage: string = '';
   imageUrl: string = '';
   countrySelected: string = '';

--- a/src/app/components/hris/employees/new-employee/new-employee.component.ts
+++ b/src/app/components/hris/employees/new-employee/new-employee.component.ts
@@ -379,6 +379,11 @@ export class NewEmployeeComponent implements OnInit {
     });
   }
 
+  public fileOver(event: Event) {
+  }
+  public fileLeave(event: Event) {
+  }
+  
   public removeFileByIndex(index: number): void {
     if (index >= 0 && index < this.files.length) {
       this.files.splice(index, 1);

--- a/src/app/components/hris/employees/new-employee/new-employee.component.ts
+++ b/src/app/components/hris/employees/new-employee/new-employee.component.ts
@@ -585,7 +585,7 @@ export class NewEmployeeComponent implements OnInit {
         : this.newEmployeeForm.value.disabilityNotes?.trim();
     this.newEmployeeForm.value.photo =
       this.newEmployeeForm.value.photo === ''
-        ? 'TBA'
+        ? ''
         : this.newEmployeeForm.value.photo?.trim();
   }
 

--- a/src/app/components/hris/employees/new-employee/new-employee.component.ts
+++ b/src/app/components/hris/employees/new-employee/new-employee.component.ts
@@ -379,10 +379,6 @@ export class NewEmployeeComponent implements OnInit {
     });
   }
 
-  public fileOver(event: Event) {
-  }
-  public fileLeave(event: Event) {
-  }
   public removeFileByIndex(index: number): void {
     if (index >= 0 && index < this.files.length) {
       this.files.splice(index, 1);


### PR DESCRIPTION
**Details:**

- Cant see the default profile image when creating a new employee.

![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/2f1de76e-5e91-4b9d-a3d0-00bb3189c49c)

**Fixed:**

- When you create a new employee you can now see the default profile image
- Made the TBA string empty because of the check for the image upload which causes issues

![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/43bd4443-c70b-4ae7-a0f2-969ac9187095)
![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/4ca8fa23-ab6e-454e-9f93-e6d30a00a10b)
![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/7289e2e7-cabe-49c7-8683-bf9f5479c46c)
![image](https://github.com/RetroRabbit/RGO-Client/assets/156097906/fb4356ec-68d8-48af-acae-df0f64a71dcf)
