### PR TITLE
9516 DEV | Employee role should not request to get all charts 

### DIFF
--- a/src/app/components/hris/nav-bar/types/top-nav/top-nav.component.ts
+++ b/src/app/components/hris/nav-bar/types/top-nav/top-nav.component.ts
@@ -64,9 +64,16 @@ export class TopNavComponent {
     this.roles = Object.keys(JSON.parse(types));
     this.navService.refreshEmployee();
     this.isLoading = false;
-    this.chartService.getAllCharts().subscribe({
-      next: (data: any) => (this.charts = data),
-    });
+    if (
+      this.authAccessService.isAdmin() ||
+      this.authAccessService.isJourney() ||
+      this.authAccessService.isSuperAdmin() ||
+      this.authAccessService.isTalent()
+    ) {    
+        this.chartService.getAllCharts().subscribe({
+        next: (data: any) => (this.charts = data),
+        });
+    }
   }
 
   searchQuery: string = '';


### PR DESCRIPTION
**9516 DEV | Employee role should not request to get all charts** 

This fix restricts employee role from requesting all charts.

[Azure bug](https://dev.azure.com/retro-rabbit/RetroGradOnboard/_sprints/taskboard/RetroGradOnboard%20Team/RetroGradOnboard/Sprint%2023?workitem=9516)