### PR TITLE
Juanro/fix missing info

### DIFF
--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-summary-qualifications/accordion-career-summary-qualifications.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-summary-qualifications/accordion-career-summary-qualifications.component.html
@@ -6,6 +6,11 @@
                 <mat-panel-title>
                     Qualifications
                 </mat-panel-title>
+                <mat-panel-description *ngIf="this.sharedAccordionFunctionality.qualificationFormProgress != 100"
+                    class="pe-0 pe-md-5">
+                    <mat-icon class="mx-1">error</mat-icon>
+                     <span class="d-none d-md-block d-lg-block">Missing Information</span>
+                </mat-panel-description>
             </mat-expansion-panel-header>
             <div class="flex-row">
                 <div class="mat-expansion-panel-content">

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-salary-details/accordion-salary-details.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-salary-details/accordion-salary-details.component.html
@@ -5,6 +5,11 @@
                 <mat-panel-title>
                     Salary Details
                 </mat-panel-title>
+                <mat-panel-description *ngIf="this.sharedAccordionFunctionality.salaryDetailsFormProgress != 100"
+                class="pe-0 pe-md-5">
+                <mat-icon class="mx-1">error</mat-icon>
+                 <span class="d-none d-md-block d-lg-block">Missing Information</span>
+            </mat-panel-description>
             </mat-expansion-panel-header>
             <form [formGroup]="sharedAccordionFunctionality.salaryDetailsForm">
                 <div class="col-12 mb-2 d-flex justify-content-end" id="space">


### PR DESCRIPTION
![image](https://github.com/RetroRabbit/RGO-Client/assets/156077669/47e6c6ba-8cea-4fbf-be1d-28dc91751186)

Added missing info banner on salary details and and qualification, no missing info text was being displayed on the accordion banners when not filled in