### PR TITLE
Refactoring the employee manage/filter page

### DIFF
--- a/src/app/components/hris/charts/charts.component.ts
+++ b/src/app/components/hris/charts/charts.component.ts
@@ -9,7 +9,7 @@ import { ChartType } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels'
 import { Renderer2, Inject } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-import { EmployeeProfile } from 'src/app/models/hris/employee-profile.interface';
+import { EmployeeFilterView } from 'src/app/models/hris/employee-filter-view.interface';
 import { EmployeeService } from 'src/app/services/hris/employee/employee.service';
 import { EmployeeType } from 'src/app/models/hris/constants/employeeTypes.constants';
 import { Chart } from 'chart.js';
@@ -207,7 +207,7 @@ export class ChartComponent implements OnInit {
 
   fetchPeopleChampionEmployees() {
     this.employeeService.filterEmployees(0, EmployeeType.PeopleChampion).subscribe({
-      next: (employees: EmployeeProfile[]) => {
+      next: (employees: EmployeeFilterView[]) => {
         employees.forEach((employee) => {
           if (employee.id) {
             this.employeeNames[employee.id] = `${employee.name} ${employee.surname}`;

--- a/src/app/components/hris/employees/view-employee/view-employee.component.html
+++ b/src/app/components/hris/employees/view-employee/view-employee.component.html
@@ -121,7 +121,7 @@
                       {{ splitAndCapitalizeCamelCase(employee.Roles.length > 0 ? employee.Roles[0] : "N/A") }}
                     </mat-label>
                     <mat-select hideSingleSelectionIndicator="true">
-                      <mat-option *ngFor="let role of roles | async" [value]="role"
+                      <mat-option *ngFor="let role of roles" [value]="role"
                         (click)="changeRole(employee.Email, role)">
                         {{ splitAndCapitalizeCamelCase(role) }}
                       </mat-option>

--- a/src/app/components/hris/employees/view-employee/view-employee.component.ts
+++ b/src/app/components/hris/employees/view-employee/view-employee.component.ts
@@ -1,4 +1,4 @@
-import { EmployeeProfile } from 'src/app/models/hris/employee-profile.interface';
+import { EmployeeFilterView } from 'src/app/models/hris/employee-filter-view.interface';
 import { EmployeeService } from 'src/app/services/hris/employee/employee.service';
 import { CookieService } from 'ngx-cookie-service';
 import { MatTableDataSource } from '@angular/material/table';
@@ -7,16 +7,15 @@ import { MatSort, Sort } from '@angular/material/sort';
 import { Router } from '@angular/router';
 import { EmployeeRoleService } from 'src/app/services/hris/employee/employee-role.service';
 import { SnackbarService } from 'src/app/services/shared-services/snackbar-service/snackbar.service';
-import { ClientService } from 'src/app/services/hris/client.service';
-import { Client } from 'src/app/models/hris/client.interface';
 import { EmployeeData } from 'src/app/models/hris/employeedata.interface';
-import { Component,Output,EventEmitter,ViewChild,HostListener,NgZone,Input,ViewEncapsulation } from '@angular/core';
-import { Observable,catchError,first,forkJoin,map,of,switchMap,tap } from 'rxjs';
+import { Component, Output, EventEmitter, ViewChild, HostListener, NgZone, Input, ViewEncapsulation } from '@angular/core';
+import { Observable, catchError, first, forkJoin, map, of, switchMap, tap } from 'rxjs';
 import { AuthAccessService } from 'src/app/services/shared-services/auth-access/auth-access.service';
 import { EmployeeType } from 'src/app/models/hris/constants/employeeTypes.constants';
 import { EmployeeTypeService } from 'src/app/services/hris/employee/employee-type.service';
 import { GenericDropDownObject } from 'src/app/models/hris/generic-drop-down-object.interface'
 import { EmployeeStatus } from 'src/app/models/hris/constants/employee-status.constants';
+import { EmployeeProfile } from 'src/app/models/hris/employee-profile.interface';
 
 @Component({
   selector: 'app-view-employee',
@@ -26,6 +25,18 @@ import { EmployeeStatus } from 'src/app/models/hris/constants/employee-status.co
 })
 
 export class ViewEmployeeComponent {
+
+  constructor(
+    private employeeService: EmployeeService,
+    private employeeRoleService: EmployeeRoleService,
+    private cookieService: CookieService,
+    private ngZone: NgZone,
+    private router: Router,
+    private snackBarService: SnackbarService,
+    public authAccessService: AuthAccessService,
+    private employeeTypeService: EmployeeTypeService
+  ) { }
+
   @Output() selectedEmployee = new EventEmitter<EmployeeProfile>();
   @Output() addEmployeeEvent = new EventEmitter<void>();
   @Output() managePermissionsEvent = new EventEmitter<void>();
@@ -34,17 +45,21 @@ export class ViewEmployeeComponent {
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
   _searchQuery: string = '';
-  filteredEmployees: EmployeeProfile[] = [];
+  filteredEmployees: EmployeeFilterView[] = [];
   employeeStatus: string[] = EmployeeStatus;
   getActiveEmployees: boolean = true;
   isLoading: boolean = true;
   defaultPageSize: number = 10
-  selectedChampion?: GenericDropDownObject;
-
-  displayedColumns: string[] = ['Name', 'Position', 'Level', 'Client', 'Roles'];
+  selectedChampion?: GenericDropDownObject = { id: 0, name: 'All' } as GenericDropDownObject;
+  displayedColumns: string[] = ['Name', 'Position', 'Level', 'Client'];
   displayedTerminatedColumns: string[] = ['terminatedNames', 'terminatedPosition', 'Tenure', 'Last Day', 'Reason'];
-
-  dataSource: MatTableDataSource<EmployeeProfile> = new MatTableDataSource();
+  dataSource: MatTableDataSource<EmployeeFilterView> = new MatTableDataSource();
+  PREVIOUS_PAGE = 'previousPage';
+  roles: string[] = [];
+  peopleChampions: Observable<GenericDropDownObject[]> = new Observable;
+  usertypes: Observable<GenericDropDownObject[]> = new Observable;
+  currentChampionFilter: GenericDropDownObject = new GenericDropDownObject;
+  currentUserTypeFilter: GenericDropDownObject = new GenericDropDownObject;
 
   @Input()
   set searchQuery(text: string) {
@@ -64,19 +79,39 @@ export class ViewEmployeeComponent {
     return this.authAccessService.isJourney();
   }
 
-  PREVIOUS_PAGE = 'previousPage';
+  ngOnInit() {
+    this.dataSource.paginator = this.paginator;
+    this.usertypes = this.getUserTypesForFilter();
+    this.peopleChampions = this.getPeopleChampionsForFilter();
+    this.employeeRoleService.getAllRoles().subscribe((data: string[]) => {
+      this.roles = data.filter((role) => !role.includes('SuperAdmin'));
+    });
 
-  roles: Observable<string[]> = this.employeeRoleService.getAllRoles().pipe(
-    map((roles: string[]) =>
-      roles.filter((role) => !role.includes('SuperAdmin'))
-    ),
-    first()
-  );
+    this.onResize();
 
-  peopleChampions: Observable<GenericDropDownObject[]> = this.getPeopleChampionsForFilter();
-  usertypes: Observable<GenericDropDownObject[]> = this.getUserTypesForFilter();
-  currentChampionFilter: GenericDropDownObject = new GenericDropDownObject;
-  currentUserTypeFilter: GenericDropDownObject = new GenericDropDownObject;
+    if (this.cookieService.get(this.PREVIOUS_PAGE) == '/dashboard') {
+      this._searchQuery = this.cookieService.get('searchString');
+    }
+
+    if (this.isAdminOrSuperAdmin) {
+      this.displayedColumns = ['Name', 'Position', 'Level', 'Client', 'Roles'];
+    }
+
+    if (this.isJourney) {
+
+      this.peopleChampions.subscribe({
+        next: data => this.selectedChampion = data.find(x => x.id == this.authAccessService.getUserId() ?? 0)
+      })
+
+    } else {
+      this.peopleChampions.subscribe({ next: data => this.selectedChampion = data.find(x => x.id == 0) })
+    }
+  }
+
+  ngAfterViewInit() {
+    this.filterEmployeeTable();
+    this.cookieService.set(this.PREVIOUS_PAGE, '/employees');
+  }
 
   onAddEmployeeClick(): void {
     this.addEmployeeEvent.emit();
@@ -84,114 +119,25 @@ export class ViewEmployeeComponent {
     this.router.navigateByUrl('/create-employee');
   }
 
-  constructor(
-    private employeeService: EmployeeService,
-    private employeeRoleService: EmployeeRoleService,
-    private clientService: ClientService,
-    private cookieService: CookieService,
-    private ngZone: NgZone,
-    private router: Router,
-    private snackBarService: SnackbarService,
-    public authAccessService: AuthAccessService,
-    private employeeTypeService: EmployeeTypeService
-  ) {
-  }
-
-  ngOnInit() {
-    this.dataSource.paginator = this.paginator;
-
-    this.peopleChampions.subscribe({
-      next: data => {
-        this.selectedChampion = data.find(x => x.id == 0)
-        console.log(this.selectedChampion)
-      }
-    })
-    
-    this.onResize();
-    if (this.cookieService.get(this.PREVIOUS_PAGE) == '/dashboard') {
-      this._searchQuery = this.cookieService.get('searchString');
-    }
-
-    if (!this.isAdminOrSuperAdmin) {
-      this.displayedColumns = ['Name', 'Position', 'Level', 'Client'];
-    }
-
-    if(this.isJourney){
-      console.log("isjourney")
-      this.peopleChampions.subscribe({
-        next: data => {
-          this.selectedChampion = data.find(x => x.id == this.authAccessService.getUserId())
-          console.log(this.selectedChampion)
-        }
-      })
-    }
-  }
-
-  ngAfterViewInit() {
-    this.getEmployees();
-    this.cookieService.set(this.PREVIOUS_PAGE, '/employees');
-  }
-
-  getEmployees(): void {
-    this.isLoading = true;
-    const clients$: Observable<Client[]> = this.clientService
-      .getAllClients()
-      .pipe(catchError(() => of([] as Client[])));
-
-    this.employeeService
-      .getEmployeeProfiles()
-      .pipe(
-        switchMap((employees: EmployeeProfile[]) =>
-          this.combineEmployeesWithRolesAndClients(employees, clients$)
-        ),
-        catchError((error) => {
-          this.snackBarService.showSnackbar('Unable to Retrieve Employees', 'snack-error');
-          return of([]);
-        }),
-        first()
-      )
-      .subscribe((data) => {
-        this.setupDataSource(data);
-        this.isLoading = false;
-        this.applySearchFilter();
-      });
-  }
-
   private combineEmployeesWithRolesAndClients(
-    employees: EmployeeProfile[],
-    clients$: Observable<Client[]>
+    employees: EmployeeFilterView[]
   ): Observable<EmployeeData[]> {
-    const rolesRequests$ = employees.map((employee) =>
-      this.employeeRoleService
-        .getRoles(employee.email!)
-        .pipe(catchError(() => of([] as string[])))
-    );
-
-    return forkJoin([of(employees), clients$, ...rolesRequests$]).pipe(
-      map(([employees, clients, ...rolesList]) =>
-        this.constructEmployeeData(employees, clients, rolesList)
-      )
+    return forkJoin([of(employees)]).pipe(
+      map(([employees]) => this.constructEmployeeData(employees))
     );
   }
 
   private constructEmployeeData(
-    employees: EmployeeProfile[],
-    clients: Client[],
-    rolesList: string[][]
+    employees: EmployeeFilterView[]
   ): EmployeeData[] {
     const employeeDataList: EmployeeData[] = employees.map(
-      (employee, index) => {
-        const client = clients.find(
-          (client) =>
-            employee.clientAllocated && client.id === +employee.clientAllocated
-        );
-        const sortedRoles = this.sortRoles(rolesList[index]);
+      (employee) => {
         return {
           Name: `${employee.name} ${employee.surname}`,
-          Position: employee.employeeType!.name,
+          Position: employee.position,
           Level: employee.level,
-          Client: client ? client.name : 'None',
-          Roles: sortedRoles,
+          Client: employee.clientAllocated ?? 'None',
+          Roles: [employee.roleDescription],
           Email: employee.email,
           engagementDate: employee.engagementDate,
           terminationDate: employee.terminationDate,
@@ -276,27 +222,17 @@ export class ViewEmployeeComponent {
     Level: number | undefined;
     Client: string;
     Roles: string[];
-    Email: string | undefined;
+    Email: string;
   }): void {
-    this.employeeService
-      .getEmployeeProfiles()
-      .pipe(
-        map(
-          (employees: EmployeeProfile[]) =>
-            employees.filter(
-              (emp: EmployeeProfile) =>
-                `${emp.name} ${emp.surname}` === `${employee.Name}`
-            )[0]
-        ),
+    this.employeeService.get(employee.Email).
+      pipe(
         tap((data) => {
           this.selectedEmployee.emit(data);
           this._searchQuery = '';
           this.router.navigateByUrl('/profile/' + data.id)
           this.cookieService.set(this.PREVIOUS_PAGE, '/employees');
-        }),
-        first()
+        })
       )
-      .subscribe();
   }
 
   screenWidth: number = 992;
@@ -340,16 +276,16 @@ export class ViewEmployeeComponent {
     return pages;
   }
 
-  changeRole(email: string, role: string): void {
+  changeRole(email: string, newRole: string): void {
     this.employeeRoleService
-      .updateRole(email, role)
+      .updateRole(email, newRole)
       .pipe(
         tap(() => {
           this.snackBarService.showSnackbar("Updated", "snack-success");
-          this.getEmployees();
         }),
-        catchError((error) => {
-          this.snackBarService.showSnackbar('Unable to Change Role', 'snack-error');
+        catchError((er) => {
+          this.snackBarService.showSnackbar(er.error, 'snack-error');
+          this.filterEmployeeTable();
           return of(null);
         })
       )
@@ -393,27 +329,24 @@ export class ViewEmployeeComponent {
   }
 
   changePeopleChampionFilter(champion: GenericDropDownObject) {
+    console.log("changePeopleChampionFilter")
     this.currentChampionFilter = champion;
     this.filterEmployeeTable();
   }
 
   changeUserTypeFilter(employeeType: GenericDropDownObject) {
+    console.log("changeUserTypeFilter")
     this.currentUserTypeFilter = employeeType;
     this.filterEmployeeTable();
   }
 
   filterEmployeeTable() {
     this.isLoading = true;
-    const clients$: Observable<Client[]> = this.clientService
-      .getAllClients()
-      .pipe(catchError(() => of([] as Client[])));
 
     this.employeeService
       .filterEmployees(this.currentChampionFilter.id || 0, this.currentUserTypeFilter.id || 0, this.getActiveEmployees)
       .pipe(
-        switchMap((employees: EmployeeProfile[]) =>
-          this.combineEmployeesWithRolesAndClients(employees, clients$)
-        ),
+        switchMap((employees: EmployeeFilterView[]) => this.combineEmployeesWithRolesAndClients(employees)),
         catchError((error) => {
           this.snackBarService.showSnackbar('Unable to Retrieve Employees', 'snack-error');
           return of([]);

--- a/src/app/models/hris/employee-filter-view.interface.ts
+++ b/src/app/models/hris/employee-filter-view.interface.ts
@@ -1,0 +1,17 @@
+export class EmployeeFilterView { 
+
+  EmployeeFilterView() {}
+
+  id!: number;
+  name!: string;
+  surname!: string;
+  level?: number;
+  clientAllocated?: string;
+  roleId!: string;
+  roleDescription!: string;
+  engagementDate?: Date;
+  terminationDate?: Date;
+  email?: string;
+  inactiveReason?: string;
+  position?: string;
+}

--- a/src/app/services/hris/employee/employee.service.ts
+++ b/src/app/services/hris/employee/employee.service.ts
@@ -7,6 +7,7 @@ import { environment } from '../../../../environments/environment';
 import { AuthAccessService } from '../../shared-services/auth-access/auth-access.service';
 import { ChurnRateDataCard } from 'src/app/models/hris/churn-rate-data-card.interface';
 import { EmployeeCountDataCard } from 'src/app/models/hris/employee-count-data-card.interface';
+import { EmployeeFilterView } from 'src/app/models/hris/employee-filter-view.interface';
 
 
 @Injectable({
@@ -102,11 +103,11 @@ export class EmployeeService {
   *
   * @returns List of EmployeeDto objects.
   */
-filterEmployees(championID: number, employeeType: number, activeStatus: boolean = true): Observable<EmployeeProfile[]> {
+filterEmployees(championID: number, employeeType: number, activeStatus: boolean = true): Observable<EmployeeFilterView[]> {
   const queryParams = `?PeopleChampId=${encodeURIComponent(championID)}
                         &employeeType=${encodeURIComponent(employeeType)}
                         &activeStatus=${activeStatus}`;
-  return this.httpClient.get<EmployeeProfile[]>(`${this.baseUrl}/filter-employees${queryParams}`);
+  return this.httpClient.get<EmployeeFilterView[]>(`${this.baseUrl}/filter-employees${queryParams}`);
 }
 
 }


### PR DESCRIPTION
When we render the list of employees on the table, we fetch each employees role, and we fetch the current list of available roles.

When we have over 150 listed, it takes more than 20sec to load the page.

Combined the required data into one collection and cached the role list so we only call it once.

Applied general error fixing and refactoring.