### PR TITLE
UI Styling Fix in Certificates Accordion

### DIFF
--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.html
@@ -74,7 +74,8 @@
                                             <mat-label>Issue date</mat-label>
                                             <input matInput [matDatepicker]="picker" placeholder="Issue date"
                                                 [(ngModel)]="copyOfCertificates[i].issueDate"
-                                                [value]="copyOfCertificates[i].issueDate">
+                                                [value]="copyOfCertificates[i].issueDate"
+                                                [matDatepickerFilter]="disableFutureDates">
                                             <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
                                             <mat-datepicker #picker></mat-datepicker>
                                         </mat-form-field>
@@ -171,7 +172,8 @@
                                     <mat-label>Issue date</mat-label>
                                     <input matInput [matDatepicker]="picker" placeholder="Issue date"
                                         [(ngModel)]="newCertificates[i].issueDate"
-                                        [value]="newCertificates[i].issueDate">
+                                        [value]="newCertificates[i].issueDate"
+                                        [matDatepickerFilter]="disableFutureDates">
                                     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
                                     <mat-datepicker #picker></mat-datepicker>
                                 </mat-form-field>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-certificates/accordion-certificates.component.ts
@@ -295,4 +295,11 @@ export class AccordionCertificatesComponent {
     });
     reader.readAsDataURL(file);
   }
+
+  currentDate: Date = new Date();
+
+  disableFutureDates = (selectedDate: Date | null): boolean => {
+    const date = (selectedDate || new Date());
+    return date <= this.currentDate;
+  }
 }


### PR DESCRIPTION
Description: Users should not be allowed to input dates that are in the future because the certificate would only be issued to the employee upon completion.

![image](https://github.com/RetroRabbit/RGO-Client/assets/123623763/94ed554a-fdba-444e-9f63-6214c77cb86d)
