### PR TITLE
Juanro/fix custom field input types

### DIFF
--- a/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.ts
+++ b/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.ts
@@ -123,7 +123,7 @@ export class SaveCustomFieldComponent {
           this.router.navigateByUrl('/system-settings');
         },
         error: (er) => {
-          this.snackBarService.showError(er)
+          this.snackBarService.showError('failed save')
         },
       });
     }

--- a/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.ts
+++ b/src/app/components/hris/custom-fields/save-custom-field/save-custom-field.component.ts
@@ -123,7 +123,7 @@ export class SaveCustomFieldComponent {
           this.router.navigateByUrl('/system-settings');
         },
         error: (er) => {
-          this.snackBarService.showError('failed save')
+          this.snackBarService.showError(er)
         },
       });
     }

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-work-experience/accordion-career-work-experience.component.html
@@ -203,7 +203,6 @@
                                                 <mat-datepicker-toggle matSuffix [for]="picker2"></mat-datepicker-toggle>
                                                 <mat-datepicker #picker2></mat-datepicker>
                                             </mat-form-field>
-
                                         </ng-template>
                                     </div>
                                     <mat-form-field class="example-full-width" appearance="outline" *ngIf="editWorkExperience; else NoEditProjectDescription">

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.css
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.css
@@ -21,3 +21,7 @@
 .headingTitle {
   font-size: 22px;
 }
+
+#style-date{
+  max-height: 24px;
+}

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.html
@@ -34,7 +34,7 @@
                           </mat-option>
                         </mat-select>
                       </div>
-                      <div *ngIf="fieldcode.type == sharedAccordionFunctionality.fieldTypes[0].id" class="d-flex align-items-center" style="max-height: 24px;">
+                      <div *ngIf="fieldcode.type == sharedAccordionFunctionality.fieldTypes[0].id" class="d-flex align-items-center" id="style-date">
                         <mat-datepicker #picker1></mat-datepicker>
                         <input matInput [matDatepicker]="picker1" formControlName="{{fieldcode.code}}">
                         <mat-datepicker-toggle matSuffix [for]="picker1"></mat-datepicker-toggle>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.html
@@ -34,7 +34,7 @@
                           </mat-option>
                         </mat-select>
                       </div>
-                      <div *ngIf="fieldcode.type == sharedAccordionFunctionality.fieldTypes[0].id" class="d-flex align-items-center">
+                      <div *ngIf="fieldcode.type == sharedAccordionFunctionality.fieldTypes[0].id" class="d-flex align-items-center" style="max-height: 24px;">
                         <mat-datepicker #picker1></mat-datepicker>
                         <input matInput [matDatepicker]="picker1" formControlName="{{fieldcode.code}}">
                         <mat-datepicker-toggle matSuffix [for]="picker1"></mat-datepicker-toggle>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.html
@@ -34,7 +34,12 @@
                           </mat-option>
                         </mat-select>
                       </div>
-                      <div *ngIf="fieldcode.type != sharedAccordionFunctionality.fieldTypes[4].id">
+                      <div *ngIf="fieldcode.type == sharedAccordionFunctionality.fieldTypes[0].id">
+                        <mat-datepicker #picker1></mat-datepicker>
+                        <input matInput [matDatepicker]="picker1" formControlName="{{fieldcode.code}}">
+                        <mat-datepicker-toggle matSuffix [for]="picker1"></mat-datepicker-toggle>
+                      </div>
+                      <div *ngIf="fieldcode.type != sharedAccordionFunctionality.fieldTypes[4].id && fieldcode.type != sharedAccordionFunctionality.fieldTypes[0].id">
                         <input matInput formControlName="{{fieldcode.code}}">
                       </div>
                     </mat-form-field>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.html
@@ -40,7 +40,7 @@
                         <mat-datepicker-toggle matSuffix [for]="picker1"></mat-datepicker-toggle>
                       </div>
                       <div *ngIf="fieldcode.type != sharedAccordionFunctionality.fieldTypes[4].id && fieldcode.type != sharedAccordionFunctionality.fieldTypes[0].id">
-                        <input matInput formControlName="{{fieldcode.code}}">
+                        <input type="number" matInput formControlName="{{fieldcode.code}}">
                       </div>
                     </mat-form-field>
                   </div>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.html
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.html
@@ -34,7 +34,7 @@
                           </mat-option>
                         </mat-select>
                       </div>
-                      <div *ngIf="fieldcode.type == sharedAccordionFunctionality.fieldTypes[0].id">
+                      <div *ngIf="fieldcode.type == sharedAccordionFunctionality.fieldTypes[0].id" class="d-flex align-items-center">
                         <mat-datepicker #picker1></mat-datepicker>
                         <input matInput [matDatepicker]="picker1" formControlName="{{fieldcode.code}}">
                         <mat-datepicker-toggle matSuffix [for]="picker1"></mat-datepicker-toggle>

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
@@ -79,7 +79,7 @@ export class AccordionProfileAdditionalComponent {
       this.employeeProfileService.getEmployeeById(this.employeeProfile.employeeDetails.id as number).subscribe({
         next: data => {
           this.employeeProfile.employeeDetails = data;
-        }, 
+        },
         complete: () => {
           this.getEmployeeData();
           this.getEmployeeTypes();
@@ -87,7 +87,7 @@ export class AccordionProfileAdditionalComponent {
             this.getAllEmployees();
           }
           this.getEmployeeFieldCodes();
-        }, 
+        },
         error: (er) => this.snackBarService.showError(er),
       })
     }
@@ -179,7 +179,7 @@ export class AccordionProfileAdditionalComponent {
 
     this.sharedAccordionFunctionality.additionalInfoForm = this.fb.group(formGroupConfig);
     this.sharedAccordionFunctionality.additionalInfoForm.disable();
-}
+  }
 
 
   editAdditionalDetails() {
@@ -212,7 +212,9 @@ export class AccordionProfileAdditionalComponent {
           fieldcodeId: found.fieldCodeId,
           value: this.sharedAccordionFunctionality.additionalInfoForm.get(formatFound)?.value
         }
-
+        if (!isNaN(employeeDataDto.value)) {
+          employeeDataDto.value = String(employeeDataDto.value);
+        }
         this.employeeDataService.updateEmployeeData(employeeDataDto).subscribe({
           next: (data) => {
             this.snackBarService.showSnackbar("Updated", "snack-success");
@@ -235,8 +237,7 @@ export class AccordionProfileAdditionalComponent {
         }
 
         if (employeeDataDto.value) {
-          if (!isNaN(employeeDataDto.value))
-          {
+          if (!isNaN(employeeDataDto.value)) {
             employeeDataDto.value = String(employeeDataDto.value);
           }
           this.employeeDataService.saveEmployeeData(employeeDataDto).subscribe({

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
@@ -181,7 +181,6 @@ export class AccordionProfileAdditionalComponent {
     this.sharedAccordionFunctionality.additionalInfoForm.disable();
   }
 
-
   editAdditionalDetails() {
     this.sharedAccordionFunctionality.additionalInfoForm.enable();
     this.sharedAccordionFunctionality.editAdditional = true;

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
@@ -202,21 +202,16 @@ export class AccordionProfileAdditionalComponent {
       const found = this.sharedAccordionFunctionality.employeeData.find((data) => {
         return fieldcode.id === data.fieldCodeId
       });
-
-
       if (found) {
         const formatFound: any = fieldcode.code
         const employeeDataDto = {
           id: found.id,
           employeeId: this.employeeId != undefined ? this.employeeId : this.loggedInProfile.id!,
           fieldcodeId: found.fieldCodeId,
-          value: this.sharedAccordionFunctionality.additionalInfoForm.get(formatFound)?.value
-        }
-        if (!isNaN(employeeDataDto.value)) {
-          employeeDataDto.value = String(employeeDataDto.value);
+          value: String(this.sharedAccordionFunctionality.additionalInfoForm.get(formatFound)?.value)
         }
         this.employeeDataService.updateEmployeeData(employeeDataDto).subscribe({
-          next: (data) => {
+          next: () => {
             this.snackBarService.showSnackbar("Updated", "snack-success");
             this.sharedAccordionFunctionality.checkAdditionalFormProgress();
             this.sharedAccordionFunctionality.totalProfileProgress();
@@ -225,7 +220,7 @@ export class AccordionProfileAdditionalComponent {
             this.getEmployeeData();
             this.updateEmployeeProfile.emit(1);
           },
-          error: (er) => this.snackBarService.showError("Failed to update field"),
+          error: () => this.snackBarService.showError("Failed to update field"),
         });
       } else {
         const formatFound: any = fieldcode?.code
@@ -233,15 +228,12 @@ export class AccordionProfileAdditionalComponent {
           id: 0,
           employeeId: this.employeeId != undefined ? this.employeeId : this.loggedInProfile.id!,
           fieldcodeId: fieldcode.id,
-          value: this.sharedAccordionFunctionality.additionalInfoForm.get(formatFound)?.value
+          value: String(this.sharedAccordionFunctionality.additionalInfoForm.get(formatFound)?.value)
         }
 
         if (employeeDataDto.value) {
-          if (!isNaN(employeeDataDto.value)) {
-            employeeDataDto.value = String(employeeDataDto.value);
-          }
           this.employeeDataService.saveEmployeeData(employeeDataDto).subscribe({
-            next: (data) => {
+            next: () => {
               this.snackBarService.showSnackbar("Saved", "snack-success");
               this.sharedAccordionFunctionality.checkAdditionalFormProgress();
               this.sharedAccordionFunctionality.totalProfileProgress();
@@ -250,7 +242,7 @@ export class AccordionProfileAdditionalComponent {
               this.getEmployeeData();
               this.updateEmployeeProfile.emit(1);
             },
-            error: (er) => this.snackBarService.showError("Failed to save field"),
+            error: () => this.snackBarService.showError("Failed to save field"),
           });
         }
       }

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
@@ -223,7 +223,7 @@ export class AccordionProfileAdditionalComponent {
             this.getEmployeeData();
             this.updateEmployeeProfile.emit(1);
           },
-          error: (er) => this.snackBarService.showError(er),
+          error: (er) => this.snackBarService.showError("Failed to update field"),
         });
       } else {
         const formatFound: any = fieldcode?.code
@@ -235,6 +235,10 @@ export class AccordionProfileAdditionalComponent {
         }
 
         if (employeeDataDto.value) {
+          if (!isNaN(employeeDataDto.value))
+          {
+            employeeDataDto.value = String(employeeDataDto.value);
+          }
           this.employeeDataService.saveEmployeeData(employeeDataDto).subscribe({
             next: (data) => {
               this.snackBarService.showSnackbar("Saved", "snack-success");
@@ -245,7 +249,7 @@ export class AccordionProfileAdditionalComponent {
               this.getEmployeeData();
               this.updateEmployeeProfile.emit(1);
             },
-            error: (er) => this.snackBarService.showError(er),
+            error: (er) => this.snackBarService.showError("Failed to save field"),
           });
         }
       }

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
@@ -168,6 +168,10 @@ export class AccordionProfileAdditionalComponent {
         if (fieldName.required == true) {
           this.sharedAccordionFunctionality.additionalInfoForm.controls[fieldName.code].setValidators(Validators.required);
         }
+        if (fieldName.regex != null)
+        {
+          this.sharedAccordionFunctionality.additionalInfoForm.controls[fieldName.code].setValidators(Validators.pattern(fieldName.regex));
+        }
         this.sharedAccordionFunctionality.additionalInfoForm.disable();
       }
     });

--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-profile/accordion-profile-additional-details/accordion-profile-additional.component.ts
@@ -162,20 +162,25 @@ export class AccordionProfileAdditionalComponent {
     const formGroupConfig: any = {};
     this.customFields.forEach(fieldName => {
       if (fieldName.code != null || fieldName.code != undefined) {
-        const customData = this.sharedAccordionFunctionality.employeeData.filter((data: EmployeeData) => data.fieldCodeId === fieldName.id)
-        formGroupConfig[fieldName.code] = new FormControl({ value: customData[0] ? customData[0].value : '', disabled: true });
-        this.sharedAccordionFunctionality.additionalInfoForm = this.fb.group(formGroupConfig);
-        if (fieldName.required == true) {
-          this.sharedAccordionFunctionality.additionalInfoForm.controls[fieldName.code].setValidators(Validators.required);
+        const customData = this.sharedAccordionFunctionality.employeeData.filter((data: EmployeeData) => data.fieldCodeId === fieldName.id);
+        const value = customData[0] ? customData[0].value : '';
+        const control = new FormControl({ value: value, disabled: true });
+        const validators = [];
+        if (fieldName.required) {
+          validators.push(Validators.required);
         }
-        if (fieldName.regex != null)
-        {
-          this.sharedAccordionFunctionality.additionalInfoForm.controls[fieldName.code].setValidators(Validators.pattern(fieldName.regex));
+        if (fieldName.regex) {
+          validators.push(Validators.pattern(fieldName.regex as string));
         }
-        this.sharedAccordionFunctionality.additionalInfoForm.disable();
+        control.setValidators(validators);
+        formGroupConfig[fieldName.code] = control;
       }
     });
-  }
+
+    this.sharedAccordionFunctionality.additionalInfoForm = this.fb.group(formGroupConfig);
+    this.sharedAccordionFunctionality.additionalInfoForm.disable();
+}
+
 
   editAdditionalDetails() {
     this.sharedAccordionFunctionality.additionalInfoForm.enable();

--- a/src/app/models/hris/custom-field.interface.ts
+++ b/src/app/models/hris/custom-field.interface.ts
@@ -10,7 +10,7 @@ export class CustomField {
   code?: string;
   name?: string;
   description?: string;
-  regex?: string;
+  regex!: string | RegExp;
   type?: number;
   status?: number;
   internal?: boolean;


### PR DESCRIPTION
- float and int fields get created and saved
- date fields gets created now
- save works for all data types
- users cannot enter letters into int and float fields

There is no input field field type for float so the best we can use is number you can make a stepper for it but that makes it strict so you will only be able to increase with 0.01 or 0.1 for example so just using a number field will allow the user to enter decimals.

![image](https://github.com/user-attachments/assets/ff12d5a4-10fb-409b-b473-8440b9597048)
![image](https://github.com/user-attachments/assets/76fd602e-2ede-4bcb-a186-1831086518b5)

