### PR TITLE
removing error for get opperations

### DIFF
--- a/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-summary-qualifications/accordion-career-summary-qualifications.component.ts
+++ b/src/app/components/hris/employees/employee-profile/accordions/accordion-career-summary/accordion-career-summary-qualifications/accordion-career-summary-qualifications.component.ts
@@ -66,7 +66,6 @@ export class CareerSummaryQualificationsComponent {
         this.sharedAccordionFunctionality.calculateQualificationProgress();
         this.sharedAccordionFunctionality.totalCareerProgress();
       },
-      error: (er) => this.snackBarService.showError(er),
     })
   }
 

--- a/src/app/components/hris/employees/employee-profile/employee-profile.component.ts
+++ b/src/app/components/hris/employees/employee-profile/employee-profile.component.ts
@@ -216,7 +216,6 @@ export class EmployeeProfileComponent implements OnChanges {
       next: (data: EmployeeTermination) => {
         this.terminationData = data;
       },
-      error: (er) => this.snackBarService.showError(er),
     });
   }
 


### PR DESCRIPTION
unauthorised access coming from employee termination since employees cant get their own termination.

no qualification data coming from qualifications if you don't have one. 